### PR TITLE
Revise branding and hero presentation for Djoglo Djawi Wangon

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Luxury Restaurant</title>
+    <title>Djoglo Djawi Wangon Rumah Makan</title>
     <link rel="stylesheet" href="style.css">
     <script defer src="script.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
@@ -11,7 +11,10 @@
 <body>
     <header class="hero">
         <nav class="navbar" aria-label="Navigasi utama">
-            <div class="logo"><img src="assets\LOGO DDW WHITE.png" alt="my-avatar" /></div>
+            <div class="logo" aria-label="Djoglo Djawi Wangon Rumah Makan">
+                <span class="logo-text">Djoglo Djawi Wangon</span>
+                <img src="assets/LOGO%20DDW%20WHITE.png" alt="Logo Djoglo Djawi Wangon" class="logo-image">
+            </div>
             
             <button class="nav-toggle" aria-label="Buka navigasi" aria-expanded="false">
                 <span class="bar"></span>
@@ -26,15 +29,15 @@
             </ul>
         </nav>
         <div class="hero-content">
-            <h1>Selamat Datang di Le Luxe</h1>
-            <p>Pengalaman kuliner mewah dengan sentuhan estetika modern.</p>
+            <h1>Selamat Datang di Djoglo Djawi Wangon</h1>
+            <p>Rumah Makan bernuansa tradisional dengan cita rasa autentik dan pelayanan hangat.</p>
             <a href="#reservation" class="btn-primary">Reservasi Sekarang</a>
         </div>
     </header>
     <section id="about" class="about">
         <div class="container">
             <h2>Tentang Kami</h2>
-            <p>Le Luxe menghadirkan suasana elegan dan menu eksklusif yang memanjakan lidah Anda. Nikmati hidangan terbaik dari chef berkelas dunia dalam atmosfer yang mewah dan nyaman.</p>
+            <p>Djoglo Djawi Wangon menghadirkan suasana hangat khas Jawa dengan menu eksklusif yang memanjakan lidah Anda. Nikmati hidangan terbaik dari para chef kami dalam atmosfer Rumah Makan yang elegan dan nyaman.</p>
         </div>
     </section>
     <section id="menu" class="menu">
@@ -42,21 +45,22 @@
             <h2>Menu Spesial</h2>
             <div class="menu-list">
                 <div class="menu-item">
-                    <img src="assets/steak.jpg" alt="Steak Premium">
+                    <img src="https://images.unsplash.com/photo-1612872087720-bb876e8ebb06?auto=format&amp;fit=crop&amp;w=800&amp;q=80" alt="Gurame asam manis dengan saus merah menggugah selera">
                     <h3>Gurame Asam Manis</h3>
-                    <p>Daging pilihan dengan saus spesial chef.</p>
+                    <p>Ikan gurame segar dengan saus asam manis khas Djoglo Djawi Wangon.</p>
                 </div>
                 <div class="menu-item">
-                    <img src="assets/salmon.jpg" alt="Salmon Truffle">
+                    <img src="https://images.unsplash.com/photo-1589302168068-964664d93dc0?auto=format&amp;fit=crop&amp;w=800&amp;q=80" alt="Semangkuk sop kaki kambing kuah susu hangat">
                     <h3>Sop Kaki Kambing Kuah Susu</h3>
-                    <p>Salmon Norwegia dengan saus truffle mewah.</p>
+                    <p>Sop kaki kambing dengan kuah susu gurih dan rempah pilihan.</p>
                 </div>
                 <div class="menu-item">
-                    <img src="assets/dessert.jpg" alt="Dessert Signature">
+                    <img src="https://images.unsplash.com/photo-1604908177071-95591a1969bd?auto=format&amp;fit=crop&amp;w=800&amp;q=80" alt="Ayam goreng kampung dengan sambal tradisional">
                     <h3>Ayam Goreng Kampung</h3>
-                    <p>Pencuci mulut eksklusif dengan plating artistik.</p>
+                    <p>Ayam kampung goreng renyah ditemani sambal trasi spesial rumah makan.</p>
                 </div>
             </div>
+            <!--
             <div class="menu-list" style="margin-top:2.5rem;">
                 <div class="menu-item">
                     <img src="assets/pasta.jpg" alt="Pasta Truffle">
@@ -74,6 +78,7 @@
                     <p>Minuman segar racikan bartender terbaik kami.</p>
                 </div>
             </div>
+            -->
         </div>
     </section>
 
@@ -81,7 +86,7 @@
     <section id="gallery" class="gallery">
         <div class="container">
             <h2>Galeri Suasana</h2>
-            <p class="gallery-subtitle">Jelajahi atmosfer elegan Le Luxe melalui beberapa potret interior dan hidangan unggulan kami.</p>
+            <p class="gallery-subtitle">Jelajahi atmosfer elegan Djoglo Djawi Wangon melalui beberapa potret interior dan hidangan unggulan kami.</p>
             <div class="gallery-grid">
                 <figure class="gallery-card">
                     <img src="https://images.unsplash.com/photo-1528605248644-14dd04022da1?auto=format&fit=crop&w=1200&q=80" alt="Interior restoran mewah" loading="lazy">
@@ -264,7 +269,7 @@
 
                 </ul>
             </div>
-            <p class="footer-copy">&copy; 2025 Le Luxe Restaurant. All rights reserved.</p>
+            <p class="footer-copy">&copy; 2025 Djoglo Djawi Wangon Rumah Makan. All rights reserved.</p>
         </div>
     </footer>
 </body>

--- a/style.css
+++ b/style.css
@@ -100,13 +100,34 @@ body {
 }
 
 header.hero {
-    background: linear-gradient(rgba(24,24,24,0.7), rgba(24,24,24,0.7)), url('assets/hero-bg.jpg') center/cover no-repeat;
+    position: relative;
+    isolation: isolate;
+    background: #181818;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     padding: 1.5rem 5vw 3.5rem 5vw;
     gap: 2rem;
+    overflow: hidden;
+}
+
+header.hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url('assets/plangddw.jpg') center/cover no-repeat;
+    filter: blur(8px) saturate(110%);
+    transform: scale(1.12);
+    z-index: -2;
+}
+
+header.hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to bottom, rgba(24,24,24,0.2) 0%, rgba(24,24,24,0.55) 55%, rgba(24,24,24,0.92) 100%);
+    z-index: -1;
 }
 .navbar {
     display: flex;
@@ -119,12 +140,24 @@ header.hero {
 .logo {
     font-family: 'Playfair Display', serif;
     font-size: 2.2rem;
-    letter-spacing: 2px;
+    letter-spacing: 1.8px;
     color: #e0b973;
     font-weight: bold;
     display: inline-flex;
-    width: 50px;
-    height: 50px;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+    line-height: 1;
+}
+
+.logo-text {
+    display: inline-block;
+}
+
+.logo-image {
+    display: none;
+    width: 125px;
+    height: auto;
 }
 .nav-links {
     list-style: none;
@@ -182,6 +215,8 @@ header.hero {
     margin: 0 auto;
     max-width: 720px;
     padding: 4.5rem 0;
+    position: relative;
+    z-index: 1;
 }
 .hero-content h1 {
     font-family: 'Playfair Display', serif;
@@ -544,6 +579,16 @@ footer {
     .navbar {
         flex-wrap: wrap;
     }
+    .logo {
+        gap: 0;
+    }
+    .logo-text {
+        display: none;
+    }
+    .logo-image {
+        display: block;
+        width: 120px;
+    }
     .nav-toggle {
         display: flex;
     }
@@ -628,8 +673,8 @@ footer {
     .navbar {
         gap: 1rem;
     }
-    .logo {
-        font-size: 1.9rem;
+    .logo-image {
+        width: 96px;
     }
     .hero-content {
         padding: 3rem 0 2.5rem;


### PR DESCRIPTION
## Summary
- update navigation to display Djoglo Djawi Wangon text branding on desktop and the provided logo asset on mobile
- refresh the hero section with the plangddw background, blur, and dark gradient for a smoother transition to following sections
- align copy, footer text, and special menu content with the new Djoglo Djawi Wangon Rumah Makan identity

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cec7e4c14c83279e1944cd0cce28be