### PR TITLE
Make navigation fixed and add horizontal specials slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,16 @@
                     <h3>Ayam Goreng Kampung</h3>
                     <p>Ayam kampung goreng renyah ditemani sambal trasi spesial rumah makan.</p>
                 </div>
+                <div class="menu-item">
+                    <img src="https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&amp;fit=crop&amp;w=800&amp;q=80" alt="Ilustrasi sajian sate signature Djoglo Djawi Wangon">
+                    <h3>Sate Maranggi Signature</h3>
+                    <p>Sate daging sapi maranggi berbumbu manis pedas dengan sambal kecap dan lalapan segar.</p>
+                </div>
+                <div class="menu-item">
+                    <img src="https://images.unsplash.com/photo-1546069901-eacef0df6022?auto=format&amp;fit=crop&amp;w=800&amp;q=80" alt="Ilustrasi rawon sapi premium dengan penyajian modern">
+                    <h3>Rawon Sapi Premium</h3>
+                    <p>Kuah kluwek pekat dengan daging sapi empuk, telur asin, dan taburan bawang goreng.</p>
+                </div>
             </div>
             <!--
             <div class="menu-list" style="margin-top:2.5rem;">

--- a/style.css
+++ b/style.css
@@ -9,6 +9,10 @@ img {
     display: block;
 }
 
+:root {
+    --nav-height: 88px;
+}
+
 /* Menu Lengkap */
 .menu-lengkap {
     background: #181818;
@@ -99,6 +103,10 @@ body {
     overflow-x: hidden;
 }
 
+[id] {
+    scroll-margin-top: calc(var(--nav-height) + 24px);
+}
+
 header.hero {
     position: relative;
     isolation: isolate;
@@ -107,7 +115,7 @@ header.hero {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    padding: 1.5rem 5vw 3.5rem 5vw;
+    padding: calc(var(--nav-height) + 2.5rem) 5vw 3.5rem 5vw;
     gap: 2rem;
     overflow: hidden;
 }
@@ -134,9 +142,16 @@ header.hero::after {
     justify-content: space-between;
     align-items: center;
     gap: 1.5rem;
-    position: relative;
-    z-index: 10;
-    
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem 5vw;
+    background: rgba(24,24,24,0.95);
+    box-shadow: 0 12px 35px rgba(0,0,0,0.45);
+    backdrop-filter: blur(12px);
+    z-index: 100;
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
 }
 .logo {
     font-family: 'Playfair Display', serif;
@@ -282,11 +297,34 @@ section {
     margin: 0 auto;
 }
 .menu-list {
-    display: flex;
-    gap: 2.5rem;
-    justify-content: center;
-    flex-wrap: wrap;
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: clamp(260px, 75vw, 320px);
+    gap: 2rem;
     margin-top: 2.5rem;
+    padding-bottom: 1.5rem;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    overscroll-behavior-x: contain;
+    scroll-snap-type: x proximity;
+    scroll-padding-inline: 5vw;
+    scroll-padding-left: 5vw;
+    scroll-padding-right: 5vw;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(224,185,115,0.45) transparent;
+}
+
+.menu-list::-webkit-scrollbar {
+    height: 8px;
+}
+
+.menu-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.menu-list::-webkit-scrollbar-thumb {
+    background: rgba(224,185,115,0.45);
+    border-radius: 999px;
 }
 .menu-item {
     background: #232323;
@@ -294,7 +332,8 @@ section {
     box-shadow: 0 2px 16px rgba(224,185,115,0.07);
     padding: 2rem 1.5rem;
     text-align: center;
-    width: min(100%, 270px);
+    width: clamp(260px, 75vw, 320px);
+    scroll-snap-align: start;
     transition: transform 0.2s, box-shadow 0.2s;
 }
 .menu-item:hover {
@@ -563,8 +602,11 @@ footer {
 
 @media (max-width: 900px) {
     .menu-list {
-        flex-direction: column;
-        align-items: center;
+        grid-auto-columns: clamp(240px, 80vw, 300px);
+        gap: 1.8rem;
+    }
+    .menu-item {
+        width: clamp(240px, 80vw, 300px);
     }
     .package-list {
         flex-direction: column;
@@ -573,12 +615,16 @@ footer {
 }
 
 @media (max-width: 768px) {
+    :root {
+        --nav-height: 84px;
+    }
     header.hero {
         min-height: auto;
-        padding: 1.5rem 5vw 3rem 5vw;
+        padding: calc(var(--nav-height) + 1.75rem) 5vw 3rem 5vw;
     }
     .navbar {
         flex-wrap: wrap;
+        padding: 0.85rem 5vw;
     }
     .logo {
         gap: 0;
@@ -596,7 +642,7 @@ footer {
     .nav-links {
         position: absolute;
         top: calc(100% + 1rem);
-        right: 0;
+        right: 5vw;
         background: rgba(24,24,24,0.95);
         border: 1px solid rgba(224,185,115,0.3);
         box-shadow: 0 10px 25px rgba(0,0,0,0.35);
@@ -649,11 +695,13 @@ footer {
     .container {
         width: 92vw;
     }
-    .menu-item {
-        width: 100%;
-    }
     .menu-list {
+        grid-auto-columns: clamp(220px, 88vw, 260px);
         gap: 1.5rem;
+        scroll-padding-inline: 4vw;
+    }
+    .menu-item {
+        width: clamp(220px, 88vw, 260px);
     }
     .hero-content h1 {
         font-size: 2.2rem;
@@ -671,8 +719,12 @@ footer {
 }
 
 @media (max-width: 480px) {
+    :root {
+        --nav-height: 78px;
+    }
     .navbar {
         gap: 1rem;
+        padding: 0.75rem 5vw;
     }
     .logo-image {
         width: 96px;


### PR DESCRIPTION
## Summary
- pin the main navigation to the top with a dark translucent background, drop shadow, and section offsets so anchored links remain visible
- turn the "Menu Spesial" grid into a horizontal scroll experience and add two new signature dishes to expand the carousel
- refine responsive breakpoints for the navbar and menu cards so the layout remains polished on tablets and phones

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68cecd7059648327903fff02c4f09f3b