### PR TITLE
Improve reservation date input guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,18 @@
             <h2>Reservasi</h2>
             <form>
                 <input type="text" name="name" placeholder="Nama" required>
-                <input type="date" name="date" required>
+                <div class="input-wrapper date-input">
+                    <input type="date" id="reservation-date" name="date" required aria-label="Tanggal reservasi">
+                    <span class="date-placeholder" aria-hidden="true">Pilih Tanggal</span>
+                    <span class="calendar-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" role="img" focusable="false">
+                            <rect x="4" y="5" width="16" height="15" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                            <line x1="4" y1="9" x2="20" y2="9" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+                            <line x1="9" y1="3" x2="9" y2="7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+                            <line x1="15" y1="3" x2="15" y2="7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
                 <select name="time" required>
                     <option value="" disabled selected>Pilih Jam</option>
                     <option value="09:00">09:00</option>

--- a/script.js
+++ b/script.js
@@ -97,6 +97,8 @@ function setupReservationForm(reservationForm) {
         return;
     }
 
+    initializeReservationDateInput(reservationForm);
+
     /**
      * Nama Fungsi: handleReservationSubmit
      * Keterangan: Membentuk pesan reservasi dari input pengguna dan membuka WhatsApp.
@@ -128,6 +130,32 @@ function setupReservationForm(reservationForm) {
     }
 
     reservationForm.addEventListener('submit', handleReservationSubmit);
+}
+
+/**
+ * Nama Fungsi: initializeReservationDateInput
+ * Keterangan: Menambahkan placeholder kustom dan ikon kalender pada input tanggal.
+ */
+function initializeReservationDateInput(reservationForm) {
+    const dateWrapper = reservationForm.querySelector('.date-input');
+    const dateField = dateWrapper?.querySelector('input[type="date"]');
+
+    if (!dateWrapper || !dateField) {
+        return;
+    }
+
+    const refreshState = () => {
+        const hasValue = Boolean(dateField.value);
+        dateWrapper.classList.toggle('has-value', hasValue);
+    };
+
+    dateField.addEventListener('input', refreshState);
+    dateField.addEventListener('change', refreshState);
+    reservationForm.addEventListener('reset', () => {
+        window.requestAnimationFrame(refreshState);
+    });
+
+    refreshState();
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -385,6 +385,56 @@ section {
     color: #fff;
     border: 1px solid #e0b973;
 }
+.reservation .input-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.date-input input[type="date"] {
+    width: 100%;
+    padding-right: 3rem;
+    cursor: pointer;
+}
+
+.date-input input[type="date"]::-webkit-calendar-picker-indicator {
+    opacity: 0;
+}
+
+.date-input .date-placeholder {
+    position: absolute;
+    top: 50%;
+    left: 1rem;
+    transform: translateY(-50%);
+    color: rgba(255, 255, 255, 0.65);
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    font-size: 1rem;
+}
+
+.date-input .calendar-icon {
+    position: absolute;
+    top: 50%;
+    right: 1rem;
+    transform: translateY(-50%);
+    color: #e0b973;
+    pointer-events: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.date-input .calendar-icon svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    display: block;
+}
+
+.date-input.has-value .date-placeholder,
+.date-input input[type="date"]:focus + .date-placeholder,
+.date-input input[type="date"]:valid + .date-placeholder {
+    opacity: 0;
+    transform: translateY(-60%);
+}
 .reservation select {
     -webkit-appearance: none;
     -moz-appearance: none;


### PR DESCRIPTION
## Summary
- add a custom wrapper for the reservation date field with a visible "Pilih Tanggal" prompt and calendar icon
- style the new date input wrapper so the placeholder appears until a date is chosen and matches the existing theme
- keep the placeholder hidden after selection via a small JavaScript helper that tracks the input value

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf7c2a2b8483278c7233c81087dd6d