### PR TITLE
Ensure Safari renders intended font weights

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Djoglo Djawi Wangon Rumah Makan</title>
     <link rel="stylesheet" href="style.css">
     <script defer src="script.js"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <nav class="navbar" aria-label="Navigasi utama">

--- a/style.css
+++ b/style.css
@@ -26,6 +26,7 @@ img {
 .menu-lengkap h2 {
     color: #e0b973;
     font-family: 'Playfair Display', serif;
+    font-weight: 700;
     text-align: center;
     margin-bottom: 2.5rem;
 }
@@ -47,6 +48,7 @@ img {
     color: #e0b973;
     font-family: 'Playfair Display', serif;
     font-size: 1.5rem;
+    font-weight: 700;
     margin-bottom: 1.2rem;
     text-align: center;
 }
@@ -98,6 +100,7 @@ img {
     font-family: 'Playfair Display', serif;
     color: #e0b973;
     font-size: 2.5rem;
+    font-weight: 700;
     margin-bottom: 1.5rem;
 }
 
@@ -250,7 +253,7 @@ header.hero::after {
     font-size: 2.1rem;
     letter-spacing: 1.8px;
     color: #e0b973;
-    font-weight: bold;
+    font-weight: 700;
     display: inline-flex;
     align-items: center;
     gap: 0.75rem;
@@ -334,6 +337,7 @@ header.hero::after {
     font-family: 'Playfair Display', serif;
     font-size: 3.5rem;
     color: #e0b973;
+    font-weight: 700;
     margin-bottom: 0;
 }
 .hero-content p {
@@ -415,6 +419,7 @@ section {
     font-family: 'Playfair Display', serif;
     color: #e0b973;
     font-size: 2.5rem;
+    font-weight: 700;
     margin-bottom: 1.5rem;
     text-align: center;
 }
@@ -466,6 +471,7 @@ section {
 .menu-item h3 {
     color: #e0b973;
     font-family: 'Playfair Display', serif;
+    font-weight: 700;
     margin-bottom: 0.5rem;
 }
 .menu-item p {
@@ -612,7 +618,7 @@ section {
     font-family: 'Playfair Display', serif;
     font-size: 1.3rem;
     margin-bottom: 0.7rem;
-    font-weight: bold;
+    font-weight: 700;
 }
 .package-desc {
     color: #fffbe6;
@@ -627,7 +633,7 @@ section {
     border: none;
     border-radius: 30px;
     font-size: 1rem;
-    font-weight: bold;
+    font-weight: 700;
     cursor: pointer;
     box-shadow: 0 4px 24px rgba(224,185,115,0.15);
     transition: background 0.2s, color 0.2s;
@@ -668,6 +674,7 @@ footer {
     font-family: 'Playfair Display', serif;
     font-size: 1.7rem;
     margin: 0 0 0.75rem 0;
+    font-weight: 700;
     color: #fff;
 }
 .footer-social-subtitle {
@@ -739,6 +746,7 @@ footer {
     font-family: 'Playfair Display', serif;
     color: #e0b973;
     font-size: 2.5rem;
+    font-weight: 700;
     text-align: center;
     margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- request the regular and bold Playfair Display and Montserrat weights from Google Fonts
- explicitly declare bold font-weight on Playfair and Montserrat elements so Safari uses the correct files

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cfe72986648327aeb2cf3ed0c8b5f7